### PR TITLE
Generate error if IP list is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ $ python3 -m pip install -r requirements.txt
 **NOTE**: You need to have [Homebrew](http://brew.sh/) installed before running the macOS/OSX installation.<br>
 **WARNING**: portSpider is only compatible with Python 3.3 & 3.4 & 3.5 & 3.6
 
+# developers:
+  * David Schütz ([@xdavidhu](https://twitter.com/xdavidhu))
+  * László Simonffy ([@Letsgo00HUN](https://twitter.com/Letsgo00HUN)) - Multithreading
+
 # contribution:
   <h4>If you have any ideas about new modules and improvements in portSpider, feel free to contribute.</h4>
   

--- a/modules/http.py
+++ b/modules/http.py
@@ -187,10 +187,12 @@ def core(moduleOptions):
 
     try:
         ipList = createIPList(network)
+        allIPs = len(ipList)
+        if allIPs == 0:
+            raise Exception
     except:
         print(RED + "[!] Invalid subnet. Exiting...\n")
         return
-    allIPs = len(ipList)
 
     threadManager = ThreadManager(ipList)
 

--- a/modules/manual.py
+++ b/modules/manual.py
@@ -144,10 +144,12 @@ def core(moduleOptions):
 
     try:
         ipList = createIPList(network)
+        allIPs = len(ipList)
+        if allIPs == 0:
+            raise Exception
     except:
         print(RED + "[!] Invalid subnet. Exiting...\n")
         return
-    allIPs = len(ipList)
 
     threadManager = ThreadManager(ipList)
 

--- a/modules/mongodb.py
+++ b/modules/mongodb.py
@@ -223,10 +223,12 @@ def core(moduleOptions):
 
     try:
         ipList = createIPList(network)
+        allIPs = len(ipList)
+        if allIPs == 0:
+            raise Exception
     except:
         print(RED + "[!] Invalid subnet. Exiting...\n")
         return
-    allIPs = len(ipList)
 
     threadManager = ThreadManager(ipList)
 

--- a/modules/mysql.py
+++ b/modules/mysql.py
@@ -237,10 +237,12 @@ def core(moduleOptions):
 
     try:
         ipList = createIPList(network)
+        allIPs = len(ipList)
+        if allIPs == 0:
+            raise Exception
     except:
         print(RED + "[!] Invalid subnet. Exiting...\n")
         return
-    allIPs = len(ipList)
 
     threadManager = ThreadManager(ipList)
 

--- a/modules/printer.py
+++ b/modules/printer.py
@@ -207,10 +207,12 @@ def core(moduleOptions):
 
     try:
         ipList = createIPList(network)
+        allIPs = len(ipList)
+        if allIPs == 0:
+            raise Exception
     except:
         print(RED + "[!] Invalid subnet. Exiting...\n")
         return
-    allIPs = len(ipList)
 
     threadManager = ThreadManager(ipList)
 

--- a/modules/ssh.py
+++ b/modules/ssh.py
@@ -138,10 +138,12 @@ def core(moduleOptions):
 
     try:
         ipList = createIPList(network)
+        allIPs = len(ipList)
+        if allIPs == 0:
+            raise Exception
     except:
         print(RED + "[!] Invalid subnet. Exiting...\n")
         return
-    allIPs = len(ipList)
 
     threadManager = ThreadManager(ipList)
 

--- a/portSpider.py
+++ b/portSpider.py
@@ -18,7 +18,7 @@ except:
     print(RED + "\n[!] Module input failed. Please make sure to install the dependencies." + END)
     raise SystemExit
 
-allModules = [["http", "Scan for open HTTP ports, and get the the titles."],
+allModules = [["http", "Scan for open HTTP ports, and get the titles."],
               ["mongodb", "Scan for open MongoDB instances, and check if they are password protected."],
               ["mysql", "Scan for open MySQL servers, and try to log in with the default credentials."],
               ["ssh", "Scan for open SSH ports."], ["printer", "Scan for open printer ports and websites."],


### PR DESCRIPTION
It would be a good idea to make sure the IP list is not empty before proceeding. This is a very basic fix for now, so it's probably best to generate a specific error for each particular condition. Let me know if you'd like me to change anything. 

**Context**:
I was running to problems when entering the `network` option. I was doing `set network 192.168.1.0` which the program accepted. Then after doing `run`, it would come up with a `TypeError` in `statusWidget()`. I realized that the `status` variable was not being initialized because the threads had no work to do because there wasn't any IP addresses to scan (the list was empty). 

Also, it would be a good idea to have some documentation or usage instructions. I assumed the program would be smart enough to realize the subnet without entering the `/24`. 